### PR TITLE
Pass floor of value to os.date for compatibility with newer LUA versions

### DIFF
--- a/opendroneid-dissector.lua
+++ b/opendroneid-dissector.lua
@@ -315,7 +315,7 @@ end
 
 -- find lag time based on rx time and 10ths of seconds since the hour tx time
 function timeDelta10(rxTime,txHour10)
-    local rxTimeParts = os.date("*t",rxTime)
+    local rxTimeParts = os.date("*t",math.floor(rxTime))
     local rxFracTime = rxTime-math.floor(rxTime) -- fractional time
     -- note: this is rounding the difference down to significant digits. 
     -- Since the fractional tenth of second is unknown (could be 0.09)
@@ -326,7 +326,7 @@ function timeDelta10(rxTime,txHour10)
 end
 
 function timeDelta10v(rxTime,txHour10)
-    local rxTimeParts = os.date("*t",rxTime)
+    local rxTimeParts = os.date("*t",math.floor(rxTime))
     local rxFracTime = rxTime-math.floor(rxTime) -- fractional time
     -- note: this is rounding the difference down to significant digits. 
     -- Since the fractional tenth of second is unknown (could be 0.09)


### PR DESCRIPTION
Newer versions of LUA do not accept non-integer inputs to the os.date function, and therefore show an error in the dissector window when trying to decode some messages, as shown when viewing odid_wifi_sample.pcap, item No 5.
<img width="1282" height="209" alt="image" src="https://github.com/user-attachments/assets/fcc9a22c-e86f-4742-ac39-dc98b2911308" />

This PR fixes this by passing the floor of the value into the function.
Tested and shown to be fixed using the same sample file, on Wireshark 4.4.7 on Windows (LUA 5.4.6).